### PR TITLE
Add __version__.py for tracking and referencing current version

### DIFF
--- a/grecy/__main__.py
+++ b/grecy/__main__.py
@@ -1,6 +1,7 @@
 import typer
 import os
 from grecy.connections import access_to
+from grecy.__version__ import __version__
 
 app = typer.Typer()
 
@@ -20,7 +21,7 @@ def install(model: str):
             exit(0)
 
         # The url for the model
-        https = hf_url + "Jacobo/" + model + "/resolve/main/" + model + "-any-py3-none-any.whl"
+        https = hf_url + "Jacobo/" + model + "/resolve/main/" + model + "-" + __version__ + "-py3-none-any.whl"
 
         # The pip command
         pip_command = "python -m pip install " + https

--- a/grecy/__version__.py
+++ b/grecy/__version__.py
@@ -1,0 +1,2 @@
+__title__ = "greCy"
+__version__ = "3.7.5"


### PR DESCRIPTION
See https://github.com/jmyerston/greCy/issues/8 for a brief discussion of the PyPi change that required this revision.

We could also move the version declaration to the __init__.py, but it seemed cleaner to add a separate file, similar to how the [requests](https://github.com/psf/requests/blob/main/src/requests/__version__.py) library handles it.

Please let me know if you have a preference or if something looks amiss!